### PR TITLE
Switch to Python 3

### DIFF
--- a/bin/pdf-link-checker
+++ b/bin/pdf-link-checker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # pdf-link-checker: report broken hyperlinks in PDF documents
 #
@@ -44,11 +44,10 @@ import time
 import socket
 import threading
 import logging as log
-import httplib
-import urllib2
-import urllib
-import urlparse
-from HTMLParser import HTMLParser
+import html
+import urllib.request
+import http.client
+from urllib.parse import urlparse
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdftypes import PDFStream
@@ -70,7 +69,7 @@ def touch(fname):
 SLASHDRV_PAT = re.compile('^/([A-Z]:)')
 
 
-def url_fix(url, charset='utf-8'):
+def url_fix(url):
     # This snippet idea has been taken from 'Werkzeug' project.
     # See: http://werkzeug.pocoo.org/
     #
@@ -82,10 +81,7 @@ def url_fix(url, charset='utf-8'):
     # Another thing we want to do is rewrite Windows file URLs
     # that urllib2 won't know how to handle otherwise.
 
-    if isinstance(url, unicode):
-        url = url.encode(charset, 'ignore')
-
-    scheme, netloc, path, qs, anchor = urlparse.urlsplit(url)
+    scheme, netloc, path, qs, anchor = urllib.parse.urlsplit(url)
 
     if scheme == 'file':
         if netloc:
@@ -97,10 +93,10 @@ def url_fix(url, charset='utf-8'):
             path = SLASHDRV_PAT.sub('\\1', path)
             #log.debug('New path: ' + path + ' for ' + str(url))
     else:
-        path = urllib.quote(path, '/%')
-        qs = urllib.quote_plus(qs, ':&=')
+        path = urllib.parse.quote(path, '/%')
+        qs = urllib.parse.quote_plus(qs, ':&=')
 
-    return urlparse.urlunsplit((scheme, netloc, path, qs, anchor))
+    return urllib.parse.urlunsplit((scheme, netloc, path, qs, anchor))
 
 
 ##########################################################
@@ -109,23 +105,22 @@ def url_fix(url, charset='utf-8'):
 
 def check_http_url(url, timeout):
 
-    request = urllib2.Request(url)
+    request = urllib.request.Request(url)
 
     # Add a browser-like User-Agent.
     # Some sites (like wikipedia) don't seem to accept requests
     # with the default urllib2 User-Agent
     request.add_header('User-Agent',
                        'Mozilla/5.0 (X11; U; Linux i686; en-US;'
-                       'rv \u2014 1.7.8) Gecko/20050511')
+                       'rv 1.7.8) Gecko/20050511')
 
     try:
-        opener = urllib2.build_opener()
-        opener.open(request, None, timeout).read()
-    except urllib2.HTTPError as why:
+        urllib.request.urlopen(request)
+    except urllib.error.HTTPError as why:
         return (False, why)
-    except urllib2.URLError as why:
+    except urllib.error.URLError as why:
         return (False, why)
-    except httplib.BadStatusLine as why:
+    except http.client.BadStatusLine as why:
         return (False, why)
     except socket.timeout as why:
         return (False, why)
@@ -141,7 +136,7 @@ def check_ftp_url(url):
     # That's why we are using urllib.urlretrieve
 
     try:
-        tmpfile = urllib.urlretrieve(url)[0]
+        tmpfile = urllib.request.urlretrieve(url)[0]
     except IOError as why:
         return (False, why)
     else:
@@ -158,11 +153,11 @@ def check_ftp_url(url):
 
 def check_non_http_or_ftp_url(url):
 
-    request = urllib2.Request(url)
+    request = urllib.request.Request(url)
     request.get_method = lambda: 'HEAD'
 
     try:
-        response = urllib2.urlopen(request)
+        urllib.request.urlopen(request)
         return (True, None)
 
     except IOError as why:
@@ -178,7 +173,7 @@ def check_non_http_or_ftp_url(url):
 
 def check_url(url, timeout):
 
-    protocol = urlparse.urlparse(url)[0]
+    protocol = urlparse(url)[0]
 
     # TODO: support relative links;
     # PDF also has 'internal links',
@@ -221,7 +216,7 @@ def check_url(url, timeout):
 
 def get_hostname(url):
 
-    return urlparse.urlparse(url)[1]
+    return urlparse(url)[1]
 
 
 def check_url_threaded(url, errors, lock, tokens_per_host,
@@ -290,13 +285,15 @@ def e(s):
 def is_valid(url):
     # we require that a protocol is given (i.e. the URL is absolute)
     # but we've only tested with http, https, ftp and file URLs
-    protocol = urlparse.urlparse(url)[0]
+    protocol = urlparse(url)[0]
     return protocol
 
 
 def search_url_string(obj):
     if isinstance(obj, str):
         return e(obj)
+    elif isinstance(obj, bytes):
+        return e(obj.decode('utf-8'))
 
 
 def search_url(obj, urls):
@@ -304,15 +301,14 @@ def search_url(obj, urls):
         return
 
     if isinstance(obj, dict):
-        for (k, v) in obj.iteritems():
+        for (k, v) in obj.items():
 
             # A dictionary with a "URI" key
             # may contain an URL string
             if k == 'URI':
                 url = search_url_string(v)
                 # Need to unescape html special characters
-                parser = HTMLParser()
-                url = parser.unescape(url)
+                url = html.unescape(url)
                 if url is not None and is_valid(url):
                     log.debug('URL found: {}'.format(url))
                     urls.add(url)
@@ -332,7 +328,7 @@ def extract_urls(filename, urls):
     log.info('Checking links in file {} ...'.format(filename))
 
     try:
-        fp = file(filename, 'rb')
+        fp = open(filename, 'rb')
         parser = PDFParser(fp)
         doc = PDFDocument(parser)
     except Exception as e:


### PR DESCRIPTION
Here's a first draft of modifying pdf-link-checker to be compatible with (only) Python 3.

So far I've tested it on the included `testing/test-document.pdf` and a few other PDFs, using both Python 3.9.6 (included with macOS 12.5.1) and Python 3.10.6 (provided by macOS Homebrew).