### PR TITLE
setup.py: use Python3 interpreter only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013 Bootlin
 


### PR DESCRIPTION
Modern distributions like, for example, Ubuntu 22.04 don't provide /usr/bin/python. Not even as a symlink.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>